### PR TITLE
Fix url decoding making folders with umlauts accessable again

### DIFF
--- a/src/background/api/filesystem.ts
+++ b/src/background/api/filesystem.ts
@@ -32,7 +32,7 @@ export const getFolderContents = (path: string) => {
     return new Promise<AxiosResponse<FsEntity[]>>((resolve, reject) => {
         let config = {
             headers: {
-                "X-FF-PATH": path,
+                "X-FF-PATH": decodeURI(path),
             },
         }
         Axios.get<FsEntity[]>(hostname + filesystemPath + "contents", config)

--- a/src/components/pages/filesytem/FilesBreadcrumb.tsx
+++ b/src/components/pages/filesytem/FilesBreadcrumb.tsx
@@ -35,7 +35,7 @@ export function FilesBreadcrumb(props: Props): ReactElement {
                         }
                         key={i}
                     >
-                        {folder}{" "}
+                        {decodeURI(folder)}
                     </Link>
                 )
             })}

--- a/src/components/pages/filesytem/__tests__/__snapshots__/FilesBreadcrumb.test.tsx.snap
+++ b/src/components/pages/filesytem/__tests__/__snapshots__/FilesBreadcrumb.test.tsx.snap
@@ -22,21 +22,18 @@ Object {
             href="/file/bla"
           >
             bla
-             
           </a>
           <a
             class="breadcrumb-item"
             href="/file/bla/fasel"
           >
             fasel
-             
           </a>
           <a
             class="breadcrumb-item active"
             href="/file/bla/fasel/file"
           >
             file
-             
           </a>
         </ol>
       </nav>
@@ -60,21 +57,18 @@ Object {
           href="/file/bla"
         >
           bla
-           
         </a>
         <a
           class="breadcrumb-item"
           href="/file/bla/fasel"
         >
           fasel
-           
         </a>
         <a
           class="breadcrumb-item active"
           href="/file/bla/fasel/file"
         >
           file
-           
         </a>
       </ol>
     </nav>


### PR DESCRIPTION
See: https://demo.filefighter.de/file/admin/tempfileshare/test%C3%A4